### PR TITLE
Soften note about View vs "V" in MVP

### DIFF
--- a/architecture.asciidoc
+++ b/architecture.asciidoc
@@ -48,7 +48,7 @@ Vaadin Designer naturally splits out all the layout configuration into the Desig
 For some application components, the split between layout and logic is not enough to deal with the complexity. There are a couple of cases in this app starter when this split just did not make the code readable and understandable. The view where you create/edit an order and the CRUD views for users and products will still be hard to read when you have split out the layout code as there is simply quite much logic code. In these cases, the MVP pattern (or a variant thereof) has been utilized so that pure business logic goes into a `presenter` class and UI related logic goes into a `view` class (there is no `model` class as the model is so simple in all the cases).
 
 [NOTE]
-Do not confuse the "V" in MVP with a `View` in Vaadin. The "V" in MVP stands for the UI part of the component while a view in Vaadin Flow stands for something which has a URL and can be navigated to using the `Router`.
+A `View` in Vaadin terminology does not quite match the "V" in MVP, where it's used to denote the UI part of the component. In Vaadin, a `View` is simply something that can be navigated to using a specific URL, as configured with the `Router`.
 
 In the cases the MVP pattern is utilized, the view decides which components to use and how to lay them out (the Design file is considered as part of the view). The view also wires event listeners, configures how fields are bound and what validators to use in the UI (validators are UI level helpers, the real data validation takes place in the service layer).
 


### PR DESCRIPTION
The note/info box about Vaadin "View" vs the "V" in MVP seemed a bit harsh ("Do not [...]"), especially for beginners who might have a hard time fully understanding the point. 

This is an attempt to "soften" the language while retaining the point, for consideration.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/bakery-app-starter-flow-docs/8)
<!-- Reviewable:end -->
